### PR TITLE
fix: use production jsx-runtime instead of jsx-dev-runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Type-safe TanStack Query integration for Elysia Eden. Like @trpc/react-query, bu
 
 | Package | Version | Size |
 |---------|---------|------|
-| [eden-tanstack-react-query](./packages/eden-tanstack-query) | 0.1.0 | **Size:** 9.85 KB (gzipped: 2.44 KB) |
+| [eden-tanstack-react-query](./packages/eden-tanstack-query) | 0.1.0 | **Size:** 9.76 KB (gzipped: 2.42 KB) |
 
 ## Quick Start
 

--- a/packages/eden-tanstack-query/README.md
+++ b/packages/eden-tanstack-query/README.md
@@ -6,7 +6,7 @@
 
 Type-safe TanStack Query integration for Elysia Eden. Like @trpc/react-query, but for Elysia.
 
-**Size:** 9.85 KB (gzipped: 2.44 KB)
+**Size:** 9.76 KB (gzipped: 2.42 KB)
 
 ## ✨ Features
 

--- a/packages/eden-tanstack-query/package.json
+++ b/packages/eden-tanstack-query/package.json
@@ -19,7 +19,7 @@
 	],
 	"scripts": {
 		"build": "bun run build:js && bun run build:types",
-		"build:js": "bun build ./src/index.ts --outdir ./dist --target browser --format esm --sourcemap=external --external react --external @tanstack/react-query --external @elysiajs/eden --external elysia",
+		"build:js": "NODE_ENV=production bun build ./src/index.ts --outdir ./dist --target browser --format esm --sourcemap=external --external react --external @tanstack/react-query --external @elysiajs/eden --external elysia",
 		"build:types": "bunx tsc -p tsconfig.build.json",
 		"dev": "bun run build --watch",
 		"test": "bun test --preload ./test-utils/happydom.ts",


### PR DESCRIPTION
## Summary
- Add empty `bunfig.toml` to workaround Bun v1.3 regression ([oven-sh/bun#23959](https://github.com/oven-sh/bun/issues/23959))
- Set `NODE_ENV=production` in build script

Production builds now correctly use `react/jsx-runtime` instead of `react/jsx-dev-runtime`.

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated package size information in README files, showing minor package footprint reduction.

* **Chores**
  * Updated build script configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->