### PR TITLE
fix: resolve skipToken/path-param handling, query-key Date collisions, and query header typing gaps, add repro examples and rewrite CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to eden-tanstack-query
+
+Thanks for contributing. This project uses a strict fork-based workflow: all changes come from branches in personal forks and are merged through pull requests.
+
+## Workflow Summary
+
+1. Fork this repository on GitHub.
+2. Clone your fork locally.
+3. Add the main repository as `upstream`.
+4. Create a feature/fix branch from an updated `main`.
+5. Run local checks.
+6. Push your branch to your fork.
+7. Open a pull request to `xkelxmc/eden-tanstack-query:main`.
+
+## Ground Rules
+
+- Do not push directly to the upstream repository.
+- Keep pull requests focused on one logical change.
+- Add or update tests for behavior changes.
+- Update docs/examples when API or behavior changes.
+
+## Prerequisites
+
+- Bun `1.3.6` (see `packageManager` in `package.json`)
+- Git
+- A GitHub account with a fork of this repository
+
+## One-Time Setup
+
+```bash
+git clone https://github.com/<your-username>/eden-tanstack-query.git
+cd eden-tanstack-query
+git remote add upstream https://github.com/xkelxmc/eden-tanstack-query.git
+git remote -v
+bun install
+```
+
+Expected remotes:
+
+- `origin` -> your fork (`<your-username>/eden-tanstack-query`)
+- `upstream` -> main repo (`xkelxmc/eden-tanstack-query`)
+
+## Start a New Change
+
+```bash
+git fetch upstream
+git switch main
+git rebase upstream/main
+git switch -c fix/short-description
+```
+
+Branch naming examples:
+
+- `fix/query-key-date-collision`
+- `feat/query-options-headers`
+- `docs/readme-input-examples`
+
+## Develop and Validate
+
+Run the same checks expected by CI before opening a PR:
+
+```bash
+bun run lint
+bun run build
+bun run test:types
+bun run test:cov
+```
+
+Optional fast pass during iteration:
+
+```bash
+bun run test
+```
+
+## Commit Style
+
+Use clear conventional commit messages:
+
+- `fix(query): support per-call headers in queryOptions input`
+- `feat(types): improve query input inference`
+- `docs(readme): clarify request shape examples`
+
+## Push and Open a Pull Request
+
+```bash
+git push -u origin <branch-name>
+```
+
+Then open a pull request:
+
+- **Base repository:** `xkelxmc/eden-tanstack-query`
+- **Base branch:** `main`
+- **Head repository:** your fork
+- **Head branch:** your feature branch
+
+## Pull Request Checklist
+
+- [ ] Branch is up to date with `upstream/main`
+- [ ] Lint, build, type checks, and tests pass locally
+- [ ] New behavior is covered by tests
+- [ ] Docs/examples were updated when relevant
+- [ ] Commit messages are clear and scoped
+- [ ] PR description includes what changed, why, and how it was validated
+
+## Keep Your Fork in Sync
+
+```bash
+git fetch upstream
+git switch main
+git merge --ff-only upstream/main
+git push origin main
+```
+
+## Reporting Issues
+
+When opening an issue, include:
+
+- Reproduction steps
+- Expected behavior
+- Actual behavior
+- Runtime/package versions
+- Minimal reproduction (if possible)
+
+## Releases
+
+Maintainers: release steps are documented in [RELEASING.md](./RELEASING.md).

--- a/packages/eden-tanstack-query/README.md
+++ b/packages/eden-tanstack-query/README.md
@@ -187,11 +187,11 @@ Pass query parameters or request body:
 
 ```typescript
 // Query params: GET /users?role=admin
-eden.users.get.queryOptions({ query: { role: 'admin' } })
+eden.users.get.queryOptions({ role: 'admin' })
 
 // With headers
 eden.users.get.queryOptions({
-  query: { role: 'admin' },
+  role: 'admin',
   headers: { 'X-Custom': 'value' }
 })
 ```

--- a/packages/eden-tanstack-query/src/keys/queryKey.ts
+++ b/packages/eden-tanstack-query/src/keys/queryKey.ts
@@ -4,8 +4,13 @@ import type { EdenMutationKey, EdenQueryKey, QueryType } from "./types"
 /**
  * Helper to check if value is a plain object
  */
-function isObject(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value)
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return false
+	}
+
+	const prototype = Object.getPrototypeOf(value)
+	return prototype === Object.prototype || prototype === null
 }
 
 /**
@@ -18,8 +23,14 @@ const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"])
  * Removes dangerous keys like __proto__, constructor, prototype.
  */
 function sanitizeInput(value: unknown): unknown {
-	if (!isObject(value)) {
-		return Array.isArray(value) ? value.map(sanitizeInput) : value
+	if (Array.isArray(value)) {
+		return value.map(sanitizeInput)
+	}
+
+	// Preserve non-plain objects (e.g. Date, Map, Set, class instances) as-is.
+	// Only plain objects are reconstructed for dangerous-key stripping.
+	if (!isPlainObject(value)) {
+		return value
 	}
 
 	const result: Record<string, unknown> = {}
@@ -80,7 +91,7 @@ export function getQueryKey(opts: GetQueryKeyOptions): EdenQueryKey {
 	const input = sanitizeInput(opts.input)
 
 	// For infinite queries, strip cursor/direction from input
-	if (type === "infinite" && isObject(input)) {
+	if (type === "infinite" && isPlainObject(input)) {
 		const inputObj = input
 		if ("cursor" in inputObj || "direction" in inputObj) {
 			const { cursor: _, direction: __, ...rest } = inputObj

--- a/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
+++ b/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
@@ -5,8 +5,8 @@
  * Transforms Eden Treaty client paths into queryOptions/mutationOptions factories.
  */
 import type { Treaty } from "@elysiajs/eden"
-import { skipToken } from "@tanstack/react-query"
 import type { QueryClient, QueryFilters } from "@tanstack/react-query"
+import { skipToken } from "@tanstack/react-query"
 import type { AnyElysia } from "elysia"
 
 import { getMutationKey, getQueryKey } from "../keys/queryKey"
@@ -121,10 +121,10 @@ function mergePathParamsIntoInputForKey(
 }
 
 /**
- * Check if a value is a non-null object.
+ * Check if a value is a non-null, non-array object.
  */
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null
+	return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 /**
@@ -137,15 +137,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function parseQueryRequestInput(input: unknown): ParsedQueryRequestInput {
 	if (!isRecord(input)) return { query: input }
 
-	const hasQuery = Object.prototype.hasOwnProperty.call(input, "query")
-	const hasHeaders = Object.prototype.hasOwnProperty.call(input, "headers")
+	const hasQuery = Object.hasOwn(input, "query")
+	const hasHeaders = Object.hasOwn(input, "headers")
 	const headersValue = hasHeaders ? input.headers : undefined
 	const hasRecordHeaders = isRecord(headersValue)
 	const hasOnlyWrappedKeys = Object.keys(input).every(
 		(key) => key === "query" || key === "headers",
 	)
 
-	if (hasQuery && hasOnlyWrappedKeys && (!hasHeaders || hasRecordHeaders)) {
+	// A lone { query: value } is a valid query object for routes with a
+	// query parameter named "query"; require the headers key to opt in.
+	if (hasQuery && hasHeaders && hasOnlyWrappedKeys) {
 		return {
 			query: input.query,
 			headers: hasRecordHeaders ? headersValue : undefined,
@@ -321,12 +323,12 @@ function createQueryProcedure(opts: ProcedureOptions) {
 				getPreviousPageParam?: (firstPage: unknown) => unknown
 				initialCursor?: unknown
 			},
-			) => {
-				const { initialCursor = null, ...restOpts } = infiniteOpts
-				const inputForKey = mergePathParamsIntoInputForKey(input, pathParams)
+		) => {
+			const { initialCursor = null, ...restOpts } = infiniteOpts
+			const inputForKey = mergePathParamsIntoInputForKey(input, pathParams)
 
-				return edenInfiniteQueryOptions({
-					path: paths,
+			return edenInfiniteQueryOptions({
+				path: paths,
 				input: inputForKey,
 				initialPageParam: initialCursor,
 				fetch: async (inputWithCursor, signal) => {
@@ -337,7 +339,11 @@ function createQueryProcedure(opts: ProcedureOptions) {
 						direction?: unknown
 					}
 					const { query: parsedQuery, headers } = parseQueryRequestInput(input)
-					const fullInput = addCursorToQueryInput(parsedQuery, cursor, direction)
+					const fullInput = addCursorToQueryInput(
+						parsedQuery,
+						cursor,
+						direction,
+					)
 					// Build path without the method
 					const pathWithoutMethod = paths.slice(0, -1)
 					const method = getMethod(paths)

--- a/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
+++ b/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
@@ -141,8 +141,11 @@ function parseQueryRequestInput(input: unknown): ParsedQueryRequestInput {
 	const hasHeaders = Object.prototype.hasOwnProperty.call(input, "headers")
 	const headersValue = hasHeaders ? input.headers : undefined
 	const hasRecordHeaders = isRecord(headersValue)
+	const hasOnlyWrappedKeys = Object.keys(input).every(
+		(key) => key === "query" || key === "headers",
+	)
 
-	if (hasQuery) {
+	if (hasQuery && hasOnlyWrappedKeys && (!hasHeaders || hasRecordHeaders)) {
 		return {
 			query: input.query,
 			headers: hasRecordHeaders ? headersValue : undefined,

--- a/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
+++ b/packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts
@@ -5,6 +5,7 @@
  * Transforms Eden Treaty client paths into queryOptions/mutationOptions factories.
  */
 import type { Treaty } from "@elysiajs/eden"
+import { skipToken } from "@tanstack/react-query"
 import type { QueryClient, QueryFilters } from "@tanstack/react-query"
 import type { AnyElysia } from "elysia"
 
@@ -56,6 +57,11 @@ export interface PositionedPathParam {
 	params: Record<string, unknown>
 }
 
+interface ParsedQueryRequestInput {
+	query: unknown
+	headers?: Record<string, unknown>
+}
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -92,6 +98,89 @@ function mergePathParams(
 	pathParams: PositionedPathParam[],
 ): Record<string, unknown> {
 	return Object.assign({}, ...pathParams.map((path) => path.params))
+}
+
+/**
+ * Merge path params into input for cache-key generation while preserving skipToken.
+ */
+function mergePathParamsIntoInputForKey(
+	input: unknown,
+	pathParams: PositionedPathParam[],
+): unknown {
+	if (pathParams.length === 0) return input
+	if (input === skipToken) return skipToken
+
+	const mergedPathParams = mergePathParams(pathParams)
+
+	if (input === undefined) return mergedPathParams
+	if (input === null) return mergedPathParams
+
+	return typeof input === "object"
+		? { ...mergedPathParams, ...(input as object) }
+		: { ...mergedPathParams, input }
+}
+
+/**
+ * Check if a value is a non-null object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null
+}
+
+/**
+ * Parse query input into Eden's request shape.
+ * Supports:
+ * - direct query input: { role: "admin" }
+ * - direct query + headers: { role: "admin", headers: {...} }
+ * - request shape: { query: { role: "admin" }, headers: {...} }
+ */
+function parseQueryRequestInput(input: unknown): ParsedQueryRequestInput {
+	if (!isRecord(input)) return { query: input }
+
+	const hasQuery = Object.prototype.hasOwnProperty.call(input, "query")
+	const hasHeaders = Object.prototype.hasOwnProperty.call(input, "headers")
+	const headersValue = hasHeaders ? input.headers : undefined
+	const hasRecordHeaders = isRecord(headersValue)
+
+	if (hasQuery) {
+		return {
+			query: input.query,
+			headers: hasRecordHeaders ? headersValue : undefined,
+		}
+	}
+
+	if (hasHeaders && hasRecordHeaders) {
+		const { headers, ...query } = input
+		return {
+			query: Object.keys(query).length > 0 ? query : undefined,
+			headers: headers as Record<string, unknown>,
+		}
+	}
+
+	return { query: input }
+}
+
+/**
+ * Add cursor/direction to an existing query input for infinite requests.
+ */
+function addCursorToQueryInput(
+	query: unknown,
+	cursor?: unknown,
+	direction?: unknown,
+): unknown {
+	const hasCursor = cursor !== undefined
+	const hasDirection = direction !== undefined
+
+	if (!hasCursor && !hasDirection) return query
+
+	const cursorInput: Record<string, unknown> = {}
+	if (hasCursor) cursorInput.cursor = cursor
+	if (hasDirection) cursorInput.direction = direction
+
+	if (isRecord(query)) return { ...query, ...cursorInput }
+	if (query === undefined || query === null) return cursorInput
+
+	return { ...cursorInput, query }
 }
 
 /**
@@ -166,17 +255,14 @@ function createQueryProcedure(opts: ProcedureOptions) {
 
 	return {
 		queryOptions: (input?: unknown, queryOpts?: unknown) => {
-			// Merge pathParams into input for unique cache keys
-			const inputForKey =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			const inputForKey = mergePathParamsIntoInputForKey(input, pathParams)
 			return edenQueryOptions({
 				path: paths,
 				input: inputForKey,
 				fetch: async (_inputForKey, signal) => {
 					// Use original input for fetch, not merged
 					const actualInput = input
+					const { query, headers } = parseQueryRequestInput(actualInput)
 					// Build path without the method
 					const pathWithoutMethod = paths.slice(0, -1)
 					const method = getMethod(paths)
@@ -193,10 +279,14 @@ function createQueryProcedure(opts: ProcedureOptions) {
 						method
 					] as (opts: unknown) => Promise<{ data: unknown; error: unknown }>
 
-					const result = await methodFn({
-						query: actualInput,
+					const requestInput: Record<string, unknown> = {
 						fetch: { signal },
-					})
+					}
+
+					if (query !== undefined) requestInput.query = query
+					if (headers !== undefined) requestInput.headers = headers
+
+					const result = await methodFn(requestInput)
 
 					if (result.error) throw result.error
 					return result.data
@@ -206,11 +296,7 @@ function createQueryProcedure(opts: ProcedureOptions) {
 		},
 
 		queryKey: (input?: unknown): EdenQueryKey => {
-			// Merge pathParams into input for unique cache keys
-			const mergedInput =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			const mergedInput = mergePathParamsIntoInputForKey(input, pathParams)
 			return getQueryKey({ path: paths, input: mergedInput, type: "query" })
 		},
 
@@ -218,10 +304,7 @@ function createQueryProcedure(opts: ProcedureOptions) {
 			input?: unknown,
 			filters?: QueryFilters,
 		): WithRequired<QueryFilters, "queryKey"> => {
-			const mergedInput =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			const mergedInput = mergePathParamsIntoInputForKey(input, pathParams)
 			return {
 				...filters,
 				queryKey: getQueryKey({ path: paths, input: mergedInput, type: "any" }),
@@ -235,29 +318,23 @@ function createQueryProcedure(opts: ProcedureOptions) {
 				getPreviousPageParam?: (firstPage: unknown) => unknown
 				initialCursor?: unknown
 			},
-		) => {
-			const { initialCursor = null, ...restOpts } = infiniteOpts
-			// Merge pathParams into input for unique cache keys
-			const inputForKey =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			) => {
+				const { initialCursor = null, ...restOpts } = infiniteOpts
+				const inputForKey = mergePathParamsIntoInputForKey(input, pathParams)
 
-			return edenInfiniteQueryOptions({
-				path: paths,
+				return edenInfiniteQueryOptions({
+					path: paths,
 				input: inputForKey,
 				initialPageParam: initialCursor,
 				fetch: async (inputWithCursor, signal) => {
 					// inputWithCursor has pathParams merged + cursor
-					// Extract cursor and use original input for query
+					// Extract cursor and merge into parsed query input
 					const { cursor, direction } = (inputWithCursor ?? {}) as {
 						cursor?: unknown
 						direction?: unknown
 					}
-					const fullInput =
-						cursor !== undefined || direction !== undefined
-							? { ...(input as object), cursor, direction }
-							: input
+					const { query: parsedQuery, headers } = parseQueryRequestInput(input)
+					const fullInput = addCursorToQueryInput(parsedQuery, cursor, direction)
 					// Build path without the method
 					const pathWithoutMethod = paths.slice(0, -1)
 					const method = getMethod(paths)
@@ -274,10 +351,14 @@ function createQueryProcedure(opts: ProcedureOptions) {
 						method
 					] as (opts: unknown) => Promise<{ data: unknown; error: unknown }>
 
-					const result = await methodFn({
-						query: fullInput,
+					const requestInput: Record<string, unknown> = {
 						fetch: { signal },
-					})
+					}
+
+					if (fullInput !== undefined) requestInput.query = fullInput
+					if (headers !== undefined) requestInput.headers = headers
+
+					const result = await methodFn(requestInput)
 
 					if (result.error) throw result.error
 					return result.data
@@ -289,10 +370,7 @@ function createQueryProcedure(opts: ProcedureOptions) {
 		},
 
 		infiniteQueryKey: (input?: unknown): EdenQueryKey => {
-			const mergedInput =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			const mergedInput = mergePathParamsIntoInputForKey(input, pathParams)
 			return getQueryKey({ path: paths, input: mergedInput, type: "infinite" })
 		},
 
@@ -300,10 +378,7 @@ function createQueryProcedure(opts: ProcedureOptions) {
 			input?: unknown,
 			filters?: QueryFilters,
 		): WithRequired<QueryFilters, "queryKey"> => {
-			const mergedInput =
-				pathParams.length > 0
-					? { ...mergePathParams(pathParams), ...(input as object) }
-					: input
+			const mergedInput = mergePathParamsIntoInputForKey(input, pathParams)
 			return {
 				...filters,
 				queryKey: getQueryKey({

--- a/packages/eden-tanstack-query/src/types/decorators.ts
+++ b/packages/eden-tanstack-query/src/types/decorators.ts
@@ -69,6 +69,50 @@ export interface EdenQueryOptionsResult {
 }
 
 /**
+ * Per-request headers accepted by Eden query calls.
+ */
+type EdenRequestHeaders = Record<string, string | undefined>
+
+/**
+ * Request-style query input with optional headers.
+ * Supports: { query: {...}, headers: {...} }
+ */
+type EdenQueryRequestInput<TInput> = Simplify<
+	({} extends TInput ? { query?: TInput } : { query: TInput }) & {
+		headers?: EdenRequestHeaders
+	}
+>
+
+/**
+ * Query input accepted by query methods.
+ * Supports:
+ * - direct query object: { role: "admin" }
+ * - direct query + headers: { role: "admin", headers: {...} }
+ * - request shape: { query: { role: "admin" }, headers: {...} }
+ */
+type EdenQueryProcedureInput<TInput> =
+	| TInput
+	| Simplify<TInput & { headers?: EdenRequestHeaders }>
+	| EdenQueryRequestInput<TInput>
+
+/**
+ * Infinite query input without cursor.
+ */
+type EdenInfiniteQueryBaseInput<TInput> = Omit<TInput, "cursor">
+
+/**
+ * Input accepted by infinite query methods.
+ */
+type EdenInfiniteQueryProcedureInput<TInput> =
+	| EdenInfiniteQueryBaseInput<TInput>
+	| Simplify<
+			EdenInfiniteQueryBaseInput<TInput> & {
+				headers?: EdenRequestHeaders
+			}
+	  >
+	| EdenQueryRequestInput<EdenInfiniteQueryBaseInput<TInput>>
+
+/**
  * Input options for undefined initial data queries.
  * Used when no initialData is provided.
  */
@@ -155,7 +199,7 @@ export interface EdenQueryOptions<TDef extends RouteDefinition> {
 	 * The returned data will never be undefined.
 	 */
 	<TQueryFnData extends TDef["output"], TData = TQueryFnData>(
-		input: EmptyToVoid<TDef["input"]> | SkipToken,
+		input: EmptyToVoid<EdenQueryProcedureInput<TDef["input"]>> | SkipToken,
 		opts: DefinedEdenQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -173,7 +217,7 @@ export interface EdenQueryOptions<TDef extends RouteDefinition> {
 	 * The returned data can be undefined until loaded.
 	 */
 	<TQueryFnData extends TDef["output"], TData = TQueryFnData>(
-		input: EmptyToVoid<TDef["input"]>,
+		input: EmptyToVoid<EdenQueryProcedureInput<TDef["input"]>>,
 		opts?: UnusedSkipTokenEdenQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -190,7 +234,7 @@ export interface EdenQueryOptions<TDef extends RouteDefinition> {
 	 * Use skipToken to conditionally disable the query.
 	 */
 	<TQueryFnData extends TDef["output"], TData = TQueryFnData>(
-		input?: EmptyToVoid<TDef["input"]> | SkipToken,
+		input?: EmptyToVoid<EdenQueryProcedureInput<TDef["input"]>> | SkipToken,
 		opts?: UndefinedEdenQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -422,7 +466,9 @@ export interface EdenInfiniteQueryOptions<TDef extends RouteDefinition> {
 		TData = TQueryFnData,
 		TPageParam = ExtractCursorType<TDef["input"]> | null,
 	>(
-		input: EmptyToVoid<Omit<TDef["input"], "cursor">> | SkipToken,
+		input:
+			| EmptyToVoid<EdenInfiniteQueryProcedureInput<TDef["input"]>>
+			| SkipToken,
 		opts: DefinedEdenInfiniteQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -444,7 +490,7 @@ export interface EdenInfiniteQueryOptions<TDef extends RouteDefinition> {
 		TData = TQueryFnData,
 		TPageParam = ExtractCursorType<TDef["input"]> | null,
 	>(
-		input: EmptyToVoid<Omit<TDef["input"], "cursor">>,
+		input: EmptyToVoid<EdenInfiniteQueryProcedureInput<TDef["input"]>>,
 		opts: UnusedSkipTokenEdenInfiniteQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -466,7 +512,9 @@ export interface EdenInfiniteQueryOptions<TDef extends RouteDefinition> {
 		TData = TQueryFnData,
 		TPageParam = ExtractCursorType<TDef["input"]> | null,
 	>(
-		input?: EmptyToVoid<Omit<TDef["input"], "cursor">> | SkipToken,
+		input?:
+			| EmptyToVoid<EdenInfiniteQueryProcedureInput<TDef["input"]>>
+			| SkipToken,
 		opts?: UndefinedEdenInfiniteQueryOptionsIn<
 			TQueryFnData,
 			TData,
@@ -525,7 +573,7 @@ export interface DecorateQueryProcedure<TDef extends RouteDefinition>
 	 * @see https://tanstack.com/query/latest/docs/framework/react/guides/query-keys
 	 */
 	queryKey: (
-		input?: DeepPartial<TDef["input"]>,
+		input?: DeepPartial<EdenQueryProcedureInput<TDef["input"]>>,
 	) => DataTag<
 		EdenQueryKey,
 		TDef["output"],
@@ -542,7 +590,7 @@ export interface DecorateQueryProcedure<TDef extends RouteDefinition>
 	 * @see https://tanstack.com/query/latest/docs/framework/react/guides/filters
 	 */
 	queryFilter: (
-		input?: DeepPartial<TDef["input"]>,
+		input?: DeepPartial<EdenQueryProcedureInput<TDef["input"]>>,
 		filters?: QueryFilters<
 			DataTag<
 				EdenQueryKey,
@@ -579,7 +627,7 @@ export interface DecorateInfiniteQueryProcedure<TDef extends RouteDefinition>
 	 * Generate an infinite query key for cache operations.
 	 */
 	infiniteQueryKey: (
-		input?: DeepPartial<Omit<TDef["input"], "cursor">>,
+		input?: DeepPartial<EdenInfiniteQueryProcedureInput<TDef["input"]>>,
 	) => DataTag<
 		EdenQueryKey,
 		TDef["output"],
@@ -590,7 +638,7 @@ export interface DecorateInfiniteQueryProcedure<TDef extends RouteDefinition>
 	 * Create an infinite query filter.
 	 */
 	infiniteQueryFilter: (
-		input?: DeepPartial<Omit<TDef["input"], "cursor">>,
+		input?: DeepPartial<EdenInfiniteQueryProcedureInput<TDef["input"]>>,
 		filters?: QueryFilters<
 			DataTag<
 				EdenQueryKey,

--- a/packages/eden-tanstack-query/test/keys/queryKey.test.ts
+++ b/packages/eden-tanstack-query/test/keys/queryKey.test.ts
@@ -130,6 +130,30 @@ describe("getQueryKey", () => {
 		expect(key).toEqual([["api", "users", "batch"], { input: ["1", "2", "3"] }])
 	})
 
+	test("preserves Date values in input without collapsing", () => {
+		const januaryDate = new Date("2026-01-01T00:00:00.000Z")
+		const februaryDate = new Date("2026-02-01T00:00:00.000Z")
+
+		const januaryKey = getQueryKey({
+			path: ["api", "reports", "get"],
+			input: { from: januaryDate },
+		})
+		const februaryKey = getQueryKey({
+			path: ["api", "reports", "get"],
+			input: { from: februaryDate },
+		})
+
+		expect(januaryKey).toEqual([
+			["api", "reports", "get"],
+			{ input: { from: januaryDate } },
+		])
+		expect(februaryKey).toEqual([
+			["api", "reports", "get"],
+			{ input: { from: februaryDate } },
+		])
+		expect(januaryKey).not.toEqual(februaryKey)
+	})
+
 	describe("prototype pollution protection", () => {
 		test("strips __proto__ from input", () => {
 			const key = getQueryKey({

--- a/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
+++ b/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
@@ -1,4 +1,5 @@
 import type { treaty } from "@elysiajs/eden"
+import { skipToken } from "@tanstack/react-query"
 import { Elysia, t } from "elysia"
 import { createEdenOptionsProxy } from "../../src/proxy/createOptionsProxy"
 import { createTestQueryClient } from "../../test-utils"
@@ -295,6 +296,70 @@ describe("createEdenOptionsProxy", () => {
 			expect(options.staleTime).toBe(5000)
 			expect(options.refetchOnWindowFocus).toBe(false)
 		})
+
+		test("queryOptions supports top-level headers and forwards them separately", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					users: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return { data: [], error: null }
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.users.get.queryOptions({
+				status: "from-top-level",
+				headers: { "X-Tenant": "acme" },
+			})
+
+			await queryClient.fetchQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({ status: "from-top-level" })
+			expect(request.headers).toEqual({ "X-Tenant": "acme" })
+		})
+
+		test("queryOptions supports request shape input with query + headers", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					users: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return { data: [], error: null }
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.users.get.queryOptions({
+				query: { status: "from-request-shape" },
+				headers: { "X-Tenant": "acme" },
+			})
+
+			await queryClient.fetchQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({ status: "from-request-shape" })
+			expect(request.headers).toEqual({ "X-Tenant": "acme" })
+		})
 	})
 
 	describe("mutation options", () => {
@@ -537,6 +602,15 @@ describe("createEdenOptionsProxy", () => {
 			expect(result).toEqual({ userId: "456", address: "123 Main St" })
 		})
 
+		test("queryOptions preserves skipToken when path params are present", () => {
+			const eden = createEden()
+			const options = eden.api.users({ id: "123" }).get.queryOptions(skipToken)
+
+			expect(typeof options.queryFn).toBe("symbol")
+			expect(Object.is(options.queryFn, skipToken)).toBe(true)
+			expect(options.queryKey).toEqual([["api", "users", "get"], { type: "query" }])
+		})
+
 		test("multiple path params at different positions work correctly", async () => {
 			// Path: /api/v1/orgs/:orgId/teams/:teamId/members
 			const capturedOrgId: string[] = []
@@ -712,6 +786,38 @@ describe("createEdenOptionsProxy", () => {
 				input: { orgId: "o1", teamId: "t2", role: "admin" },
 				type: "query",
 			})
+		})
+
+		test("infiniteQueryOptions preserves skipToken when path params are present", () => {
+			const mockClient = {
+				api: {
+					comments: (_params: { postId: string }) => ({
+						get: async () => ({
+							data: { items: [], nextCursor: null },
+							error: null,
+						}),
+					}),
+				},
+			}
+
+			const eden = createEdenOptionsProxy<any>({
+				client: mockClient as any,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Testing custom route structure
+			const options = (eden as any).api
+				.comments({ postId: "42" })
+				.get.infiniteQueryOptions(skipToken, {
+					getNextPageParam: () => undefined,
+				})
+
+			expect(typeof options.queryFn).toBe("symbol")
+			expect(Object.is(options.queryFn, skipToken)).toBe(true)
+			expect(options.queryKey).toEqual([
+				["api", "comments", "get"],
+				{ type: "infinite" },
+			])
 		})
 	})
 

--- a/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
+++ b/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
@@ -361,6 +361,69 @@ describe("createEdenOptionsProxy", () => {
 			expect(request.headers).toEqual({ "X-Tenant": "acme" })
 		})
 
+		test("queryOptions keeps a lone query key as query input", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					users: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return { data: [], error: null }
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.users.get.queryOptions({
+				query: "hello",
+			})
+
+			await queryClient.fetchQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({ query: "hello" })
+			expect("headers" in request).toBe(false)
+		})
+
+		test("queryOptions supports request shape input with undefined headers", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					users: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return { data: [], error: null }
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.users.get.queryOptions({
+				query: { role: "admin-with-undefined-headers" },
+				headers: undefined,
+			})
+
+			await queryClient.fetchQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({ role: "admin-with-undefined-headers" })
+			expect("headers" in request).toBe(false)
+		})
+
 		test("queryOptions preserves extra top-level fields when input contains query key", async () => {
 			let capturedRequest: unknown
 
@@ -639,7 +702,10 @@ describe("createEdenOptionsProxy", () => {
 
 			expect(typeof options.queryFn).toBe("symbol")
 			expect(Object.is(options.queryFn, skipToken)).toBe(true)
-			expect(options.queryKey).toEqual([["api", "users", "get"], { type: "query" }])
+			expect(options.queryKey).toEqual([
+				["api", "users", "get"],
+				{ type: "query" },
+			])
 		})
 
 		test("multiple path params at different positions work correctly", async () => {
@@ -866,6 +932,46 @@ describe("createEdenOptionsProxy", () => {
 			expect(options.queryKey[0]).toEqual(["api", "posts", "get"])
 			expect(options.eden.path).toBe("api.posts.get")
 			expect(typeof options.queryFn).toBe("function")
+		})
+
+		test("infiniteQueryOptions wraps array input when adding a cursor", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					posts: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return {
+								data: { items: [], nextCursor: null },
+								error: null,
+							}
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.posts.get.infiniteQueryOptions(
+				["a", "b"],
+				{
+					getNextPageParam: () => undefined,
+					initialCursor: "cursor-1",
+				},
+			)
+
+			await queryClient.fetchInfiniteQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({
+				cursor: "cursor-1",
+				query: ["a", "b"],
+			})
 		})
 
 		test("infiniteQueryFilter generates correct filter", () => {

--- a/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
+++ b/packages/eden-tanstack-query/test/proxy/createOptionsProxy.test.ts
@@ -360,6 +360,37 @@ describe("createEdenOptionsProxy", () => {
 			expect(request.query).toEqual({ status: "from-request-shape" })
 			expect(request.headers).toEqual({ "X-Tenant": "acme" })
 		})
+
+		test("queryOptions preserves extra top-level fields when input contains query key", async () => {
+			let capturedRequest: unknown
+
+			const clientWithCapture = {
+				api: {
+					users: {
+						get: async (opts?: unknown) => {
+							capturedRequest = opts
+							return { data: [], error: null }
+						},
+					},
+				},
+			} as unknown as ReturnType<typeof treaty<App>>
+
+			const eden = createEdenOptionsProxy<App>({
+				client: clientWithCapture,
+				queryClient,
+			})
+
+			// biome-ignore lint/suspicious/noExplicitAny: Runtime behavior validation
+			const options = (eden as any).api.users.get.queryOptions({
+				query: "foo",
+				page: 1,
+			})
+
+			await queryClient.fetchQuery(options)
+
+			const request = capturedRequest as Record<string, unknown>
+			expect(request.query).toEqual({ query: "foo", page: 1 })
+		})
 	})
 
 	describe("mutation options", () => {

--- a/packages/eden-tanstack-query/test/types/decorators.test.ts
+++ b/packages/eden-tanstack-query/test/types/decorators.test.ts
@@ -831,6 +831,36 @@ describe("EdenOptionsProxy queryOptions return types", () => {
 		expect(hasMutationKey).toBe(true)
 		expect(hasMutationFn).toBe(true)
 	})
+
+	test("queryOptions input allows top-level headers", () => {
+		type UsersGet = Proxy["users"]["get"]
+		type QueryInput = Parameters<UsersGet["queryOptions"]>[0]
+
+		type AcceptsHeaders = {
+			search?: string
+			headers?: Record<string, string | undefined>
+		} extends QueryInput
+			? true
+			: false
+
+		const acceptsHeaders: AcceptsHeaders = true
+		expect(acceptsHeaders).toBe(true)
+	})
+
+	test("queryOptions input allows request-shape query + headers", () => {
+		type UsersGet = Proxy["users"]["get"]
+		type QueryInput = Parameters<UsersGet["queryOptions"]>[0]
+
+		type AcceptsRequestShape = {
+			query?: { search?: string }
+			headers?: Record<string, string | undefined>
+		} extends QueryInput
+			? true
+			: false
+
+		const acceptsRequestShape: AcceptsRequestShape = true
+		expect(acceptsRequestShape).toBe(true)
+	})
 })
 
 // ============================================================================


### PR DESCRIPTION
## Summary

  This PR fixes three production-relevant integration issues in Eden Treaty + TanStack Query:

  1. skipToken with path params now stays a real skipToken and no longer turns into an executable query.
  2. Query-key sanitization now preserves non-plain objects (like Date) to prevent cache key collisions.
  3. Query input now supports per-call headers in queryOptions, including both { ...query, headers } and { query,
     headers } shapes, with correct runtime forwarding.

  ## Problem

  - Disabled queries could run unexpectedly when path params were merged with skipToken.
  - Different non-plain inputs could collapse to equivalent keys during sanitization.
  - Query calls needing request-level headers were blocked by typing and not cleanly supported at runtime.

  ## Solution

  - Added skipToken-safe path param merge logic and regression coverage.
  - Updated key sanitization to only reconstruct plain objects and preserve non-plain object identity.
  - Expanded query procedure input types to support header-aware request shapes.
  - Added runtime parsing that separates query and headers before calling Eden client methods.
  - Added type and runtime tests for new request-shape behavior.

  ## Validation

  - bun run test passes.
  - bun run test:types passes.
  - Repro typecheck for issue 4 passes with no headers property error.

  ## Impact

  - Safer conditional querying.
  - More reliable cache behavior for advanced input types.
  - Production-friendly per-request header support without workarounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-request headers can be attached directly to query and infinite-query inputs; inputs accept direct, wrapped (query+headers), or header-only shapes.
  * Cache-key generation now consistently incorporates route path parameters.

* **Improvements**
  * Stricter input sanitization that preserves non-plain objects (e.g., Date) and sanitizes arrays element-wise.
  * skipToken behavior preserved for key generation and fetch paths; request shape forwarding refined.

* **Documentation**
  * Added CONTRIBUTING.md; updated README examples for query/header usage.

* **Tests**
  * Added tests for header shapes, skipToken behavior, Date preservation, and request forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves three production-critical issues in Eden Treaty + TanStack Query integration:

- **skipToken preservation**: `skipToken` now correctly stays disabled when path params are present, preventing unexpected query execution
- **Cache key collision fix**: Non-plain objects (Date, Map, Set) are preserved in query keys instead of being reconstructed, ensuring distinct cache entries
- **Per-request headers**: Query methods now accept headers in three formats: direct query + headers, request shape with separate query/headers properties, and direct query object

The implementation is thorough with strong type safety and comprehensive test coverage. All changes maintain backward compatibility while fixing real production bugs.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no blocking issues found
- Well-designed fixes with comprehensive test coverage, proper type safety, backward compatibility maintained, and clear documentation via CONTRIBUTING.md
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/eden-tanstack-query/src/keys/queryKey.ts | renamed `isObject` to `isPlainObject` with prototype checking to preserve non-plain objects (Date, Map, Set) and prevent cache key collisions |
| packages/eden-tanstack-query/src/proxy/createOptionsProxy.ts | added `skipToken` preservation in path param merge, implemented header-aware query input parsing with three input shapes, and separated query/headers in Eden client calls |
| packages/eden-tanstack-query/src/types/decorators.ts | added `EdenQueryProcedureInput` and `EdenInfiniteQueryProcedureInput` types to support three header input shapes: direct query, query + headers, and request shape |

</details>



<sub>Last reviewed commit: 26ee688</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=b0cf9fa6-22a3-42f1-976c-fe5bd5ce876c))

<!-- /greptile_comment -->